### PR TITLE
feat: Store JWT secret and ensure autoApproveWebSocketRegistrations s…

### DIFF
--- a/src/lib/configManager.ts
+++ b/src/lib/configManager.ts
@@ -8,10 +8,12 @@ const CONFIG_FILE_PATH = path.join(DATA_DIR, CONFIG_FILE_NAME);
 
 export interface RuntimeConfig {
   autoApproveWebSocketRegistrations: boolean;
+  jwtSecret: string;
 }
 
 const defaultConfig: RuntimeConfig = {
   autoApproveWebSocketRegistrations: false,
+  jwtSecret: 'PLEASE_SET_A_STRONG_JWT_SECRET', // Placeholder, ensure proper handling if used
 };
 
 /**
@@ -35,14 +37,32 @@ export async function loadConfiguration(): Promise<RuntimeConfig> {
   await ensureDataDirExists();
   try {
     const fileContent = await fs.readFile(CONFIG_FILE_PATH, 'utf-8');
-    const config = JSON.parse(fileContent) as RuntimeConfig;
-    // Basic validation: check if the expected property exists
+    let config = JSON.parse(fileContent) as Partial<RuntimeConfig>; // Parse as partial first
+
+    // Validate and ensure all config fields are present, merging with defaults
+    let configChanged = false;
     if (typeof config.autoApproveWebSocketRegistrations !== 'boolean') {
-        console.warn(`Invalid or missing 'autoApproveWebSocketRegistrations' in ${CONFIG_FILE_PATH}. Using default.`);
-        return await initializeDefaultConfig();
+        console.warn(`Invalid or missing 'autoApproveWebSocketRegistrations' in ${CONFIG_FILE_PATH}. Setting to default: ${defaultConfig.autoApproveWebSocketRegistrations}`);
+        config.autoApproveWebSocketRegistrations = defaultConfig.autoApproveWebSocketRegistrations;
+        configChanged = true;
     }
+    if (typeof config.jwtSecret !== 'string' || config.jwtSecret === '') {
+        console.warn(`Invalid or missing 'jwtSecret' in ${CONFIG_FILE_PATH}. Setting to default placeholder.`);
+        config.jwtSecret = defaultConfig.jwtSecret; // Use placeholder from defaultConfig
+        configChanged = true;
+    }
+
+    const finalConfig = config as RuntimeConfig; // Now cast to full RuntimeConfig
+
+    if (configChanged) {
+        console.log(`Configuration updated with default values for missing fields. Saving new version to ${CONFIG_FILE_PATH}`);
+        // Save the corrected/updated config back to the file
+        // Note: initializeDefaultConfig writes the complete defaultConfig, here we want to preserve existing valid fields.
+        await fs.writeFile(CONFIG_FILE_PATH, JSON.stringify(finalConfig, null, 2), 'utf-8');
+    }
+
     console.log(`Configuration loaded from ${CONFIG_FILE_PATH}`);
-    return config;
+    return finalConfig;
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       console.log(`${CONFIG_FILE_PATH} not found. Initializing with default configuration.`);
@@ -80,7 +100,7 @@ export async function saveConfiguration(config: RuntimeConfig): Promise<void> {
     console.log(`Configuration saved to ${CONFIG_FILE_PATH}`);
   } catch (error) {
     console.error(`Failed to save configuration to ${CONFIG_FILE_PATH}:`, error);
-    // Depending on desired behavior, we might re-throw or handle this
-    // For now, just logging, but this means a save failure won't be explicitly reported to caller
+    // Re-throw the error so the caller can handle it
+    throw error;
   }
 }


### PR DESCRIPTION
…aves

- Modifies `configManager.ts` to include `jwtSecret` in `RuntimeConfig`.
- Updates `loadConfiguration` to handle missing `jwtSecret` in existing configs and initialize it with a placeholder.
- Modifies `saveConfiguration` to re-throw errors, allowing callers to handle save failures.
- Updates `httpServer.ts` to prioritize JWT secret sources:
  1. `process.env.JWT_SECRET`
  2. `runtimeConfig.jwtSecret` from `data/runtime-config.json`
  3. Placeholder secret (with strong warnings if used).
- Ensures that changes to `autoApproveWebSocketRegistrations` via the admin UI correctly save to `data/runtime-config.json` and that failures in saving are reported more clearly.