### PR TITLE
Fix TypeScript error and add port configuration

### DIFF
--- a/src/http/httpServer.ts
+++ b/src/http/httpServer.ts
@@ -352,11 +352,12 @@ export async function startHttpServer(port: number, serverAdminPassword?: string
     res.json({ autoApproveEnabled: autoApproveWebSocketRegistrations });
   });
 
-  app.post('/admin/settings/toggle-auto-approve-ws', adminAuth, csrfProtection, async (req, res) => {
+  app.post('/admin/settings/toggle-auto-approve-ws', adminAuth, csrfProtection, async (req, res): Promise<void> => {
     const { enable } = req.body; // Expecting { "enable": boolean }
 
     if (typeof enable !== 'boolean') {
-      return res.status(400).json({ message: "Invalid request body. 'enable' boolean field required." });
+      res.status(400).json({ message: "Invalid request body. 'enable' boolean field required." });
+      return;
     }
 
     autoApproveWebSocketRegistrations = enable;
@@ -373,6 +374,7 @@ export async function startHttpServer(port: number, serverAdminPassword?: string
             autoApproveEnabled: currentConfig.autoApproveWebSocketRegistrations,
             message: `WebSocket auto-approval ${autoApproveWebSocketRegistrations ? 'enabled' : 'disabled'}. State saved.`
         });
+        return;
     } catch (error) {
         console.error("Error saving auto-approve configuration:", error);
         // Note: The in-memory state was already updated. If save fails, they are now out of sync.
@@ -385,6 +387,7 @@ export async function startHttpServer(port: number, serverAdminPassword?: string
             message: `WebSocket auto-approval ${autoApproveWebSocketRegistrations ? 'enabled' : 'disabled'}. ERROR SAVING STATE.`,
             error: "Failed to persist setting."
         });
+        return;
     }
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,18 @@ import { startHttpServer } from './http/httpServer';
 import { startWebSocketServer } from './websocket/wsServer';
 import dotenv from 'dotenv';
 
+import { loadConfiguration } from './lib/configManager'; // Import loadConfiguration
+
 // Load environment variables from .env file
 dotenv.config();
 
-const HTTP_PORT = parseInt(process.env.HTTP_PORT || '3000', 10);
-const WS_PORT = parseInt(process.env.WS_PORT || '3001', 10);
+// Default ports, can be overridden by env vars or config file
+const DEFAULT_HTTP_PORT = 3000;
+const DEFAULT_WS_PORT = 3001;
+
+let HTTP_PORT = parseInt(process.env.HTTP_PORT || `${DEFAULT_HTTP_PORT}`, 10);
+let WS_PORT = parseInt(process.env.WS_PORT || `${DEFAULT_WS_PORT}`, 10);
+
 
 // Store servers for graceful shutdown
 // httpServerInstance will be Promise<ReturnType<typeof startHttpServer>> due to async startHttpServer
@@ -53,6 +60,26 @@ async function getPassword(): Promise<string> {
 
 async function startServer() {
   console.log('Starting Key/Info Manager Server...');
+
+  // Load runtime configuration to potentially override ports
+  try {
+    const runtimeConfig = await loadConfiguration();
+    if (runtimeConfig.httpPort) {
+      HTTP_PORT = runtimeConfig.httpPort;
+      console.log(`HTTP port loaded from runtime-config.json: ${HTTP_PORT}`);
+    } else {
+      console.log(`HTTP port not specified in runtime-config.json, using default/env: ${HTTP_PORT}`);
+    }
+    if (runtimeConfig.wsPort) {
+      WS_PORT = runtimeConfig.wsPort;
+      console.log(`WebSocket port loaded from runtime-config.json: ${WS_PORT}`);
+    } else {
+      console.log(`WebSocket port not specified in runtime-config.json, using default/env: ${WS_PORT}`);
+    }
+  } catch (error) {
+    console.warn("Could not load runtime configuration for ports, will use defaults/env variables. Error:", error);
+  }
+
   const password = await getPassword();
 
   if (!password && !process.env.MASTER_PASSWORD) {


### PR DESCRIPTION
- Resolved TS2769 error in httpServer.ts by ensuring the async route handler for toggle-auto-approve-ws correctly returns Promise<void> and uses explicit returns after res.json() calls.
- Added httpPort and wsPort to RuntimeConfig interface and updated configManager.ts to load these from runtime-config.json.
- Modified main.ts to prioritize ports from runtime-config.json, then environment variables, then hardcoded defaults.
- Verified through testing that the build succeeds and servers start on correctly prioritized ports.