### PR TITLE
feat: Implement JSON file-based configuration management

### DIFF
--- a/src/lib/configManager.ts
+++ b/src/lib/configManager.ts
@@ -1,0 +1,121 @@
+import fs from 'fs';
+import path from 'path';
+
+const CONFIG_DIR = path.join(__dirname, '../../../data'); // Relative to src/lib, so ../../data
+const CONFIG_FILE_PATH = path.join(CONFIG_DIR, 'runtime-config.json');
+
+export interface AppConfig {
+  jwtSecret: string;
+  autoApproveWebSocketRegistrations: boolean;
+  httpPort: number;
+  wsPort: number;
+  adminPasswordHash?: string; // Optional: if we ever move admin password here
+  wsAdminPasswordHash?: string; // Optional: if we ever move ws admin password here
+}
+
+const DEFAULT_CONFIG: AppConfig = {
+  jwtSecret: 'DEFAULT_FALLBACK_SECRET_DO_NOT_USE_IN_PROD',
+  autoApproveWebSocketRegistrations: false,
+  httpPort: 3000,
+  wsPort: 3001,
+};
+
+let currentConfig: AppConfig;
+
+function ensureDirExists(dirPath: string) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+    console.log(`Created directory: ${dirPath}`);
+  }
+}
+
+export function saveConfig(configToSave: AppConfig): void {
+  ensureDirExists(CONFIG_DIR);
+  try {
+    fs.writeFileSync(CONFIG_FILE_PATH, JSON.stringify(configToSave, null, 2));
+    console.log(`Configuration saved to ${CONFIG_FILE_PATH}`);
+  } catch (error) {
+    console.error(`Error saving configuration to ${CONFIG_FILE_PATH}:`, error);
+    // Depending on severity, might want to throw or handle differently
+  }
+}
+
+export function loadConfig(): AppConfig {
+  ensureDirExists(CONFIG_DIR);
+  let loadedConfig: Partial<AppConfig> = {};
+  let needsSave = false;
+
+  try {
+    if (fs.existsSync(CONFIG_FILE_PATH)) {
+      const fileContent = fs.readFileSync(CONFIG_FILE_PATH, 'utf-8');
+      loadedConfig = JSON.parse(fileContent) as Partial<AppConfig>;
+    } else {
+      console.log(`Configuration file not found at ${CONFIG_FILE_PATH}. Creating with default values.`);
+      loadedConfig = {}; // Start fresh to ensure all defaults are applied
+      needsSave = true; // Mark that we need to save after defaulting
+    }
+  } catch (error) {
+    console.error(`Error reading or parsing configuration file ${CONFIG_FILE_PATH}. Using defaults. Error:`, error);
+    loadedConfig = {}; // Reset to ensure defaults are applied on error
+    needsSave = true; // Mark for save if parsing failed
+  }
+
+  // Merge with defaults (defaults apply if key is missing in loadedConfig)
+  const configWithDefaults: AppConfig = {
+    jwtSecret: loadedConfig.jwtSecret ?? DEFAULT_CONFIG.jwtSecret,
+    autoApproveWebSocketRegistrations: loadedConfig.autoApproveWebSocketRegistrations ?? DEFAULT_CONFIG.autoApproveWebSocketRegistrations,
+    httpPort: loadedConfig.httpPort ?? DEFAULT_CONFIG.httpPort,
+    wsPort: loadedConfig.wsPort ?? DEFAULT_CONFIG.wsPort,
+    adminPasswordHash: loadedConfig.adminPasswordHash, // Keep undefined if not present
+    wsAdminPasswordHash: loadedConfig.wsAdminPasswordHash, // Keep undefined if not present
+  };
+
+  // Check if any default values were applied to an existing file or if the file was new
+  if (!needsSave) { // Only re-check if not already marked for save (e.g. new file or parse error)
+      if (
+          configWithDefaults.jwtSecret !== loadedConfig.jwtSecret ||
+          configWithDefaults.autoApproveWebSocketRegistrations !== loadedConfig.autoApproveWebSocketRegistrations ||
+          configWithDefaults.httpPort !== loadedConfig.httpPort ||
+          configWithDefaults.wsPort !== loadedConfig.wsPort
+          // We don't check optional fields like adminPasswordHash for needing a save if they were merely defaulted from undefined to undefined
+      ) {
+          console.log('Configuration file was missing some keys. Applying defaults and saving.');
+          needsSave = true;
+      }
+  }
+
+
+  if (configWithDefaults.jwtSecret === DEFAULT_CONFIG.jwtSecret) {
+    console.warn('WARNING: Using default JWT secret. This is NOT secure for production. Consider setting a unique JWT_SECRET in data/runtime-config.json.');
+  }
+
+  if (needsSave) {
+    saveConfig(configWithDefaults);
+  }
+
+  currentConfig = configWithDefaults;
+  console.log('Configuration loaded:', currentConfig);
+  return currentConfig;
+}
+
+export function getConfig(): AppConfig {
+  if (!currentConfig) {
+    // This should ideally not be hit if loadConfig is called at startup.
+    console.warn("Config not loaded yet. Loading now. Ensure loadConfig() is called at application start.");
+    return loadConfig();
+  }
+  return currentConfig;
+}
+
+export function updateAutoApproveSetting(newState: boolean): AppConfig {
+  if (!currentConfig) {
+    loadConfig(); // Ensure config is loaded
+  }
+  currentConfig.autoApproveWebSocketRegistrations = newState;
+  saveConfig(currentConfig);
+  return currentConfig;
+}
+
+// Initialize config on module load.
+// This ensures that `getConfig` can be called immediately after import.
+loadConfig();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,12 +4,14 @@ import { initializeDataManager } from './lib/dataManager';
 import { startHttpServer } from './http/httpServer';
 import { startWebSocketServer } from './websocket/wsServer';
 import dotenv from 'dotenv';
+import { getConfig } from './lib/configManager';
 
-// Load environment variables from .env file
+// Load environment variables from .env file (e.g., for MASTER_PASSWORD)
 dotenv.config();
 
-const HTTP_PORT = parseInt(process.env.HTTP_PORT || '3000', 10);
-const WS_PORT = parseInt(process.env.WS_PORT || '3001', 10);
+// Configuration will be loaded by configManager and accessed via getConfig()
+// const HTTP_PORT = parseInt(process.env.HTTP_PORT || '3000', 10); // Now from config
+// const WS_PORT = parseInt(process.env.WS_PORT || '3001', 10); // Now from config
 
 // Store servers for graceful shutdown
 let httpServerInstance: ReturnType<typeof startHttpServer> | null = null;
@@ -72,15 +74,17 @@ async function startServer() {
     return;
   }
 
-  console.log(`Attempting to start HTTP server on port ${HTTP_PORT}...`);
-  httpServerInstance = startHttpServer(HTTP_PORT, password);
+  const config = getConfig(); // Load configuration
 
-  console.log(`Attempting to start WebSocket server on port ${WS_PORT}...`);
-  wsServerInstance = startWebSocketServer(WS_PORT);
+  console.log(`Attempting to start HTTP server on port ${config.httpPort}...`);
+  httpServerInstance = startHttpServer(config.httpPort, password);
+
+  console.log(`Attempting to start WebSocket server on port ${config.wsPort}...`);
+  wsServerInstance = startWebSocketServer(config.wsPort);
 
   console.log('Server started successfully.');
-  console.log(`Admin UI accessible via HTTP server (e.g., http://localhost:${HTTP_PORT}/admin)`);
-  console.log(`WebSocket connections on ws://localhost:${WS_PORT}`);
+  console.log(`Admin UI accessible via HTTP server (e.g., http://localhost:${config.httpPort}/admin)`);
+  console.log(`WebSocket connections on ws://localhost:${config.wsPort}`);
 }
 
 function gracefulShutdown(signal: string) {

--- a/src/websocket/wsServer.ts
+++ b/src/websocket/wsServer.ts
@@ -1,7 +1,7 @@
 // WebSocket server logic
 import WebSocket from 'ws';
 import * as DataManager from '../lib/dataManager';
-import { autoApproveWebSocketRegistrations } from '../http/httpServer'; // Import the flag
+import { getConfig } from '../lib/configManager'; // Import getConfig
 
 // Extend WebSocket instance type to hold authentication state and rate limit data
 interface AuthenticatedWebSocket extends WebSocket {
@@ -197,7 +197,7 @@ export function startWebSocketServer(port: number) {
             console.log(`Client "${newClient.name}" (ID: ${newClient.id}) registration submitted.`);
 
             // Auto-approve if flag is set
-            if (autoApproveWebSocketRegistrations) {
+            if (getConfig().autoApproveWebSocketRegistrations) {
               console.log(`Auto-approving client ${newClient.id} (debug mode).`);
               try {
                 await DataManager.approveClient(newClient.id);


### PR DESCRIPTION
Introduced a configuration manager (`src/lib/configManager.ts`) to handle application settings, storing them in `data/runtime-config.json`.

Key changes:
- Settings include JWT secret, HTTP/WS ports, and WebSocket auto-approval.
- Configuration file is created with defaults (ports 3000/3001, auto-approve false, default JWT secret) if missing on startup.
- JWT secret is now sourced from this config file, removing direct environment variable dependency for it in `httpServer.ts`.
- HTTP and WebSocket ports are now sourced from this config file via `main.ts`.
- The `autoApproveWebSocketRegistrations` setting is now persisted to the config file when changed through the admin UI.
- Updated `httpServer.ts`, `wsServer.ts`, and `main.ts` to use the new config manager.
- Verified `.gitignore` already covers the new config file path.