### PR TITLE
Fix: Use managingClientGroups in clients.ejs

### DIFF
--- a/views/clients.ejs
+++ b/views/clients.ejs
@@ -43,7 +43,7 @@
             </div>
         <% } %>
 
-        <% if (!managingClientSecrets) { %>
+        <% if (!managingClientGroups) { %>
         <div style="margin-bottom: 20px; padding: 10px; border: 1px solid #eee; background-color: #f9f9f9;">
             <h3>WebSocket Settings (Debug)</h3>
             <form action="/admin/settings/toggle-auto-approve-ws" method="POST">


### PR DESCRIPTION
The template `views/clients.ejs` was referencing an undefined variable `managingClientSecrets`. This was due to a rename of this variable to `managingClientGroups` in the route handler (`src/http/httpServer.ts`).

This commit updates the template to use the correct variable name, resolving the ReferenceError.