### PR TITLE
Refactor: Improve security of WS error handling

### DIFF
--- a/src/websocket/wsServer.ts
+++ b/src/websocket/wsServer.ts
@@ -210,7 +210,7 @@ export function startWebSocketServer(port: number) {
 
           } catch (error: any) {
             console.error("Registration error:", error);
-            sendWsResponse(ws, "ERROR", WsResponseCodes.INTERNAL_SERVER_ERROR, { detail: `Registration failed: ${error.message}` }, clientRequestId);
+            sendWsResponse(ws, "ERROR", WsResponseCodes.INTERNAL_SERVER_ERROR, { detail: "An internal error occurred during registration. Please try again later or contact support if the issue persists." }, clientRequestId);
           }
           break;
 
@@ -277,7 +277,7 @@ export function startWebSocketServer(port: number) {
                 }
               } catch (error: any) {
                 console.error("Error processing REQUEST_SECRET:", error);
-                sendWsResponse(ws, "ERROR", WsResponseCodes.INTERNAL_SERVER_ERROR, { detail: `Error requesting secret: ${error.message}` }, clientRequestId);
+                sendWsResponse(ws, "ERROR", WsResponseCodes.INTERNAL_SERVER_ERROR, { detail: "An internal error occurred while requesting the secret. Please try again later." }, clientRequestId);
               }
               break;
 
@@ -287,7 +287,7 @@ export function startWebSocketServer(port: number) {
                 sendWsResponse(ws, "AUTHORIZED_SECRETS_LIST", WsResponseCodes.OK, { authorizedSecretKeys: authorizedKeys }, clientRequestId);
               } catch (error: any) {
                 console.error("Error processing LIST_AUTHORIZED_SECRETS:", error);
-                sendWsResponse(ws, "ERROR", WsResponseCodes.INTERNAL_SERVER_ERROR, { detail: `Error listing authorized secrets: ${error.message}` }, clientRequestId);
+                sendWsResponse(ws, "ERROR", WsResponseCodes.INTERNAL_SERVER_ERROR, { detail: "An internal error occurred while listing authorized secrets. Please try again later." }, clientRequestId);
               }
               break;
 


### PR DESCRIPTION
Extends previous error handling improvements to the WebSocket server (src/websocket/wsServer.ts).

Replaced direct exposure of error.message in WebSocket responses for internal server errors with generic messages. This prevents potential leakage of sensitive internal system details to WebSocket clients.

Detailed error messages continue to be logged server-side via console.error for debugging purposes.

Specific changes:
- Modified catch blocks for REGISTER_CLIENT, REQUEST_SECRET, and LIST_AUTHORIZED_SECRETS to send generic error details in the WebSocket response payload.